### PR TITLE
Fix incorrect CI checks URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ZK Gacha Game Demo
 
-[![CI Checks](https://github.com/YOUR_USERNAME/zk-gacha-game/actions/workflows/ci.yml/badge.svg)](https://github.com/YOUR_USERNAME/zk-gacha-game/actions/workflows/ci.yml)
+[![CI Checks](https://github.com/glycogen94/zk-gacha-game/actions/workflows/ci.yml/badge.svg)](https://github.com/glycogen94/zk-gacha-game/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 **A demonstration of a verifiable gacha (loot box) game using Zero-Knowledge Proofs (ZK-SNARKs).**


### PR DESCRIPTION
Update the CI checks URL in the `README.md` file.

* Change the CI checks URL to `https://github.com/glycogen94/zk-gacha-game/actions/workflows/ci.yml/badge.svg` in the `README.md` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/glycogen94/zk-gacha-game/pull/1?shareId=22aa0255-35bc-4b60-b621-afc9d32439ba).